### PR TITLE
Fix wpan setup

### DIFF
--- a/doc/hardware/README.md
+++ b/doc/hardware/README.md
@@ -22,8 +22,12 @@ with a constrained device over a serial cable.
 
 Choose instructions from one of the methods below to flash creator onto your gateway device.
 
-* Download a prebuilt creator OpenWRT image and install dependencies through OPKG (Currently unsupported)
-* Manually build creator on the host machine and flash the gateway device using Sysupgrade. [Instructions](doc/hardware/manually_building_creator.md)
+* Download a prebuilt creator OpenWRT image from[downloads server](http://downloads.creatordev.io/creator-openwrt/v2/pistachio/marduk/creatorci40-v1.1.0-2.ubi) and install dependencies through OPKG (Currently unsupported)
+
+	root@myCi40:opkg update
+	root@myCi40:opkg install kmod-fs-nfs
+
+* Manually build creator on the host machine and flash the gateway device using Sysupgrade. [Instructions](manually_building_creator.md)
 
 Make sure to record the IP address of the gateway device by typing:
 
@@ -99,8 +103,8 @@ following error:
 Follow one of the instructions below to flash the test app onto the constrained device.
 
 * Flashing the constrained device using the gateway device using
-  [Pickle](doc/hardware/flashing_constrained_device_from_gateway.md) (preferred).
-* Flashing the constrained device using the [host machine](doc/hardware/flashing_constrained_device_from_host.md)
+  [Pickle](flashing_constrained_device_from_gateway.md) (preferred).
+* Flashing the constrained device using the [host machine](flashing_constrained_device_from_host.md)
   (requires manually switching the serial cable connected to the constrained device between the host machine and
   gateway device).
 

--- a/hardware/set-wpan-channel.py
+++ b/hardware/set-wpan-channel.py
@@ -27,8 +27,8 @@ channel = int(sys.argv[1]) if len(sys.argv) > 1 else 26
 print("Setting WPAN Channel: %d" % (channel, ))
 
 filename = '/etc/config/network'
-old_prefix = "option 'channel' '26'"
-new_prefix = "option 'channel' '%d'" % (channel, )
+old_prefix = "option channel '26'"
+new_prefix = "option channel '%d'" % (channel, )
 
 s = open(filename).read()
 s = s.replace(old_prefix, new_prefix)

--- a/hardware/setup-openwrt
+++ b/hardware/setup-openwrt
@@ -30,8 +30,9 @@ if [ -z "$CHANNEL" ]
     CHANNEL=26
 fi
 
-python fix-lan-prefix.py
-python set-wpan-channel.py $CHANNEL
+python3 fix-lan-prefix.py
+python3 set-wpan-channel.py $CHANNEL
+/etc/init.d/network restart
 ash open-helper-ports
 /etc/init.d/firewall restart
 


### PR DESCRIPTION
 Update Readme for running tests on hardware:
    1.Add link to download creator openwrt image from downloads server.
    2.Fix links to internal documentation.
    3.Add instructions to install kmod-fs-nfs required for NFS mounting.
fix setting up wpan channel using python3 scripts
fix set-wpan-channel python script

this fixes #7 